### PR TITLE
Fixed image handing on mutating webhook for images with all 3 components

### DIFF
--- a/cmd/kubenab/main.go
+++ b/cmd/kubenab/main.go
@@ -162,7 +162,14 @@ func handleContainer(container *v1.Container, dockerRegistryUrl string) bool {
 		message := fmt.Sprintf("Image is not being pulled from Private Registry: %s", container.Image)
 		log.Printf(message)
 
-		newImage := dockerRegistryUrl + "/" + container.Image
+		imageParts := strings.Split(container.Image, "/")
+		newImage := ""
+		if len(imageParts) < 3 {
+			newImage = dockerRegistryUrl + "/" + container.Image
+		} else {
+			imageParts[0] = dockerRegistryUrl
+			newImage = strings.Join(imageParts, "/")
+		}
 		log.Printf("Changing image registry to: %s", newImage)
 
 		container.Image = newImage


### PR DESCRIPTION
Is this case, we cannot add the desired registry url as a prefix. Instead we need to replace the first part.