### PR TITLE
Fix multi container bug

### DIFF
--- a/chart/kubenab/templates/mutating-webhook.yaml
+++ b/chart/kubenab/templates/mutating-webhook.yaml
@@ -10,7 +10,7 @@ metadata:
 webhooks:
 - name: kubenab-mutate.k8s.io
   rules:
-  - operations: [ "CREATE" ]
+  - operations: [ "CREATE", "UPDATE" ]
     apiGroups: [""]
     apiVersions: ["v1"]
     resources: ["pods"]

--- a/chart/kubenab/templates/validating-webhook.yaml
+++ b/chart/kubenab/templates/validating-webhook.yaml
@@ -16,6 +16,7 @@ webhooks:
     - v1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - pods
   failurePolicy: Ignore

--- a/webhook/kubenab-mutating-webhook-configuration.yaml
+++ b/webhook/kubenab-mutating-webhook-configuration.yaml
@@ -5,7 +5,7 @@ metadata:
 webhooks:
 - name: kubenab-mutate.kubenab.com
   rules:
-  - operations: [ "CREATE" ]
+  - operations: [ "CREATE", "UPDATE" ]
     apiGroups: [""]
     apiVersions: ["v1"]
     resources: ["pods"]

--- a/webhook/kubenab-validating-webhook-configuration.yaml
+++ b/webhook/kubenab-validating-webhook-configuration.yaml
@@ -11,6 +11,7 @@ webhooks:
     - v1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - pods
   failurePolicy: Ignore


### PR DESCRIPTION
This Patch will fix the Bug described in #21 by returning as Patch Operation `replace` and the path to the Container-Image.

This Patch also adds the `UPDATE` Operation to the _Mutate_ and _Validate_ Webhooks to prevent future Issues if a User (or Operator) patches/ changes the Pod instead of re-creating.

Closes #21 