### PR TITLE
Add AppVersion, BuildDate and GitHash to main Pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+GIT_HASH=$(shell git rev-parse HEAD)
+BUILD_DATE=$(shell date -u '+%Y-%m-%d_%I:%M:%S%p')
+APP_VERSION=$(shell git describe --abbrev=0 --tags)
 
 .PHONY: image
 image:
@@ -12,4 +15,4 @@ build: export GOPROXY=https://gocenter.io
 build:
 	@echo "++ Building kubenab go binary..."
 	mkdir -p bin
-	cd cmd/kubenab && go build -a --installsuffix cgo --ldflags="-s" -o ../../bin/kubenab
+	cd cmd/kubenab && go build -a --installsuffix cgo --ldflags="-s -X main.AppVersion=$(APP_VERSION) -X main.BuildDate=$(BUILD_DATE) -X main.GitHash=$(GIT_HASH)" -o ../../bin/kubenab

--- a/cmd/kubenab/main.go
+++ b/cmd/kubenab/main.go
@@ -16,6 +16,9 @@ var (
 )
 
 func main() {
+	// print Version Informations
+	log.Printf("Starting kubenab version %s - %s - %s", AppVersion, BuildDate, GitHash)
+
 	// check if all required Flags are set and in a correct Format
 	checkArguments()
 

--- a/cmd/kubenab/version.go
+++ b/cmd/kubenab/version.go
@@ -1,0 +1,9 @@
+package main
+
+// This File contains only the Version Informations about `kubenab`
+
+var (
+	AppVersion = "** NOT SET **" // Contains a SemVer Version
+	BuildDate  = "** NOT SET **" // Contains the UTC Build Time
+	GitHash    = "** NOT SET **" // Contains the SHA1 Hash of the last Commit
+)


### PR DESCRIPTION
Add the dynamic Variables `AppVersion`, `BuildDate` and `GitHash` to the
`main` Package.

This will help to easier get the current Version of the Application and
then we know on which Git Hash it was build – this will help use on Bug
Reports (and Debugging).