### PR TITLE
Add new Fields to `goreleaser`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,9 +12,11 @@ builds:
       - windows
     goarch:
       - amd64
-archive:
-  format: tar.gz
-  files:
-    - LICENSE
+archives:
+  - format: tar.gz
+    name_template: "kubenab_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,8 @@ builds:
       - windows
     goarch:
       - amd64
+    flags:
+      - -tags 'strip_debug'
 archives:
   - format: tar.gz
     name_template: "kubenab_{{ .Version }}_{{ .Os }}_{{ .Arch }}"

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ build:
 	git fetch --tags
 	@echo "++ Building kubenab go binary..."
 	mkdir -p bin
-	cd cmd/kubenab && go build $(STRIP_DEBUG) -a --installsuffix cgo --ldflags="-s -X main.AppVersion=$(APP_VERSION) -X main.BuildDate=$(BUILD_DATE) -X main.GitHash=$(GIT_HASH)" -o $(OUT_DIR)/kubenab
+	cd cmd/kubenab && go build $(STRIP_DEBUG) -a --installsuffix cgo --ldflags="-s -X main.version=$(APP_VERSION) -X main.date=$(BUILD_DATE) -X main.commit=$(GIT_HASH)" -o $(OUT_DIR)/kubenab

--- a/cmd/kubenab/main.go
+++ b/cmd/kubenab/main.go
@@ -17,7 +17,7 @@ var (
 
 func main() {
 	// print Version Informations
-	log.Printf("Starting kubenab version %s - %s - %s", AppVersion, BuildDate, GitHash)
+	log.Printf("Starting kubenab version %s - %s - %s", version, date, commit)
 
 	// check if all required Flags are set and in a correct Format
 	checkArguments()

--- a/cmd/kubenab/version.go
+++ b/cmd/kubenab/version.go
@@ -3,7 +3,7 @@ package main
 // This File contains only the Version Informations about `kubenab`
 
 var (
-	AppVersion = "** NOT SET **" // Contains a SemVer Version
-	BuildDate  = "** NOT SET **" // Contains the UTC Build Time
-	GitHash    = "** NOT SET **" // Contains the SHA1 Hash of the last Commit
+	version = "** NOT SET **" // Contains a SemVer Version
+	date    = "** NOT SET **" // Contains the UTC Build Time
+	commit  = "** NOT SET **" // Contains the SHA1 Hash of the last Commit
 )


### PR DESCRIPTION
Add support of the App Info Variable Fields (Version, Build Date, Commit) and
the `strip_debug` Flag to the `goreleaser.yaml` Config.

And also remove/ update the Deprecated `archive` Field[1][].

Closes #30 

[1]: https://goreleaser.com/deprecations#archive