### PR TITLE
Feature/chart improvements

### DIFF
--- a/chart/kubenab/Chart.yaml
+++ b/chart/kubenab/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubenab
-version: 0.0.8
+version: 0.0.9
 appVersion: 0.3.3
 home: https://github.com/jfrog/kubenab
 kubeVersion: ">=1.12.0"

--- a/chart/kubenab/templates/deployment.yaml
+++ b/chart/kubenab/templates/deployment.yaml
@@ -19,7 +19,9 @@ spec:
       labels:
 {{ include "kubenab.labels" . | indent 8 }}
     spec:
-      priorityClassName: system-cluster-critical
+      {{- if .Values.priorityClass.enabled }}
+      priorityClassName: {{ .Values.priorityClass.name | default "system-cluster-critical" }}
+      {{- end }}
       serviceAccountName: {{ include "kubenab.fullname" . }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/kubenab/templates/mutating-webhook.yaml
+++ b/chart/kubenab/templates/mutating-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ include "kubenab.labels" . | indent 4 }}
   annotations:
-    certmanager.k8s.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "kubenab.servingCertificate" . }}"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "kubenab.servingCertificate" . }}"
 webhooks:
 - name: kubenab-mutate.k8s.io
   rules:

--- a/chart/kubenab/templates/pki.yaml
+++ b/chart/kubenab/templates/pki.yaml
@@ -3,7 +3,7 @@
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing kubenab serving certificates
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: {{ include "kubenab.selfSignedIssuer" . }}
@@ -14,7 +14,7 @@ spec:
   selfSigned: {}
 ---
 # Generate a CA Certificate used to sign certificates for the kubenab
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ include "kubenab.rootCACertificate" . }}
@@ -30,7 +30,7 @@ spec:
   isCA: true
 ---
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: {{ include "kubenab.rootCAIssuer" . }}
@@ -42,7 +42,7 @@ spec:
     secretName: {{ include "kubenab.rootCACertificate" . }}
 ---
 # Finally, generate a serving certificate for the kubenab to use
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ include "kubenab.servingCertificate" . }}

--- a/chart/kubenab/templates/validating-webhook.yaml
+++ b/chart/kubenab/templates/validating-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ include "kubenab.labels" . | indent 4 }}
   annotations:
-    certmanager.k8s.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "kubenab.servingCertificate" . }}"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "kubenab.servingCertificate" . }}"
 webhooks:
 - name: kubenab-validate.jfrog.com
   rules:

--- a/chart/kubenab/values.yaml
+++ b/chart/kubenab/values.yaml
@@ -112,6 +112,11 @@ resources:
     cpu: 50m
     memory: 64Mi
 
+# Defines priorityClass to run the deployment
+priorityClass:
+    enabled: true
+    name: system-cluster-critical
+
 ## Role Based Access Control
 rbac:
   create: true


### PR DESCRIPTION
Hi,

Thanks for the project. 

I had some trouble using the helm chart as is due to the following problems:
- certmanager.k8s.io annotations are not used anymore in upstream cert-manager
- wanted to deploy kubenab in an another namespace than kube-system, but couldn't due to priorityClass
- Resources were not namespaced
- kubeversion couldn't deal with EKS's version tags e.g. `v1.14.7-eks-1861c5`

In addition I removed the capabilities statement regarding `extensions/v1beta1` as it was removed in kubernetes 1.16 https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ 

My changes should be backwards compatible (with the exception of  `extension/v1beta1`).
I'd really like this to be merged upstream, so I don't have to maintain a fork, and am eager to hear your thoughts/comments.

Kind regards,
Lasse