### PR TITLE
Chart: Add securityContext and health probes, with sane defaults

### DIFF
--- a/chart/kubenab/Chart.yaml
+++ b/chart/kubenab/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubenab
-version: 0.0.10
+version: 0.0.11
 appVersion: 0.3.3
 home: https://github.com/jfrog/kubenab
 kubeVersion: ">=1.12.0"

--- a/chart/kubenab/templates/deployment.yaml
+++ b/chart/kubenab/templates/deployment.yaml
@@ -54,6 +54,18 @@ spec:
               mountPath: /etc/admission-controller/tls
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.securityContext.enabled }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- end }}
+        {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 12 }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/kubenab/values.yaml
+++ b/chart/kubenab/values.yaml
@@ -113,6 +113,41 @@ resources:
     cpu: 50m
     memory: 64Mi
 
+# Defines securityContext for deployment to remove all permissions
+# that are not needed.
+securityContext:
+  enabled: true
+  privileged: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# Defines livenessProbe to monitor deployment
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 1
+  failureThreshold: 10
+  periodSeconds: 10
+  httpGet:
+    path: "/ping"
+    port: 4443
+    scheme: HTTPS
+
+# Defines readinessProbe to monitor deployment
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 1
+  failureThreshold: 10
+  periodSeconds: 10
+  httpGet:
+    path: "/ping"
+    port: 4443
+    scheme: HTTPS
+
 # Defines priorityClass to run the deployment
 priorityClass:
     enabled: true


### PR DESCRIPTION
Adding sane security context and health probes to the Helm Chart.


Analysis before using Polaris:
![image](https://user-images.githubusercontent.com/18327738/116400158-03c0ec80-a82a-11eb-98e0-4fd2323e4e92.png)

Analysis after using Polaris:
![image](https://user-images.githubusercontent.com/18327738/116400193-0d4a5480-a82a-11eb-93a5-8a883ce5fd27.png)
