### PR TITLE
Omitting 'enabled' in securityContext, livenessProbe and readinessProbe

### DIFF
--- a/chart/kubenab/Chart.yaml
+++ b/chart/kubenab/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubenab
-version: 0.0.11
+version: 0.0.12
 appVersion: 0.3.3
 home: https://github.com/jfrog/kubenab
 kubeVersion: ">=1.12.0"

--- a/chart/kubenab/templates/deployment.yaml
+++ b/chart/kubenab/templates/deployment.yaml
@@ -56,15 +56,15 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.securityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-          {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Otherwise  the resulting yaml may by decline, as the "enabled" field is not allowed by the schema.